### PR TITLE
Added first draft of CSARTemplate yaml file

### DIFF
--- a/Examples/CSARTemplateYAML/Custom_InstallVM.yml
+++ b/Examples/CSARTemplateYAML/Custom_InstallVM.yml
@@ -1,0 +1,7 @@
+# This is an interface definition with related operations
+# ToDO: Define operations in artifact?
+Custom_InstallVM:
+	InstallVMwithCustomKeypair:
+	InstallVMwithGeneratedKeypair:
+	InstallVMwithCustomFlavor:
+	InstallVMwithCustomImage:

--- a/Examples/CSARTemplateYAML/ns2__WAR.tosca
+++ b/Examples/CSARTemplateYAML/ns2__WAR.tosca
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<tosca:Definitions xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" xmlns:ns31="http://www.eclipse.org/winery/model/selfservice" id="winery-defs-for_ns2-WAR" targetNamespace="http://www.example.com/ToscaTypes">
+    <tosca:ArtifactType name="WAR" targetNamespace="http://www.example.com/ToscaTypes"/>
+</tosca:Definitions>

--- a/Examples/CSARTemplateYAML/ns4__UbuntuNodeTypeImplementation.tosca
+++ b/Examples/CSARTemplateYAML/ns4__UbuntuNodeTypeImplementation.tosca
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<tosca:Definitions xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" xmlns:ns31="http://www.eclipse.org/winery/model/selfservice" id="winery-defs-for_ns4-UbuntuNodeTypeImplementation" targetNamespace="http://www.example.com/tosca/Types/Moodle">
+    <tosca:Import namespace="http://www.example.com/tosca/Types/Moodle" location="../imports/http%253A%252F%252Fwww.w3.org%252F2001%252FXMLSchema/http%253A%252F%252Fwww.example.com%252Ftosca%252FTypes%252FMoodle/MoodleTypes/MoodleTypes.xsd" importType="http://www.w3.org/2001/XMLSchema"/>
+    <tosca:Import namespace="http://www.uni-stuttgart.de/opentosca" location="../imports/http%253A%252F%252Fwww.w3.org%252F2001%252FXMLSchema/http%253A%252F%252Fwww.uni-stuttgart.de%252Fopentosca/WSProperties/WSProperties.xsd" importType="http://www.w3.org/2001/XMLSchema"/>
+    <tosca:Import namespace="http://www.example.com/tosca/Types/Moodle" location="ns4__UbuntuNodeTypeImplementation_IA_ArtifactTemplate.tosca" importType="http://docs.oasis-open.org/tosca/ns/2011/12"/>
+    <tosca:Import namespace="http://www.example.com/ToscaTypes" location="ns2__WAR.tosca" importType="http://docs.oasis-open.org/tosca/ns/2011/12"/>
+    <tosca:NodeTypeImplementation xmlns:ns5="http://docs.oasis-open.org/tosca/ns/2011/12/ToscaBaseTypes" name="UbuntuNodeTypeImplementation" targetNamespace="http://www.example.com/tosca/Types/Moodle" nodeType="ns5:OperatingSystem">
+        <tosca:ImplementationArtifacts>
+            <tosca:ImplementationArtifact xmlns:ns2="http://www.example.com/ToscaTypes" xmlns:ns4="http://www.example.com/tosca/Types/Moodle" interfaceName="InterfaceUbuntu" artifactType="ns2:WAR" artifactRef="ns4:UbuntuNodeTypeImplementation_IA_ArtifactTemplate"/>
+        </tosca:ImplementationArtifacts>
+    </tosca:NodeTypeImplementation>
+</tosca:Definitions>

--- a/Examples/CSARTemplateYAML/ns4__UbuntuNodeTypeImplementation_IA_ArtifactTemplate.tosca
+++ b/Examples/CSARTemplateYAML/ns4__UbuntuNodeTypeImplementation_IA_ArtifactTemplate.tosca
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<tosca:Definitions xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" xmlns:ns31="http://www.eclipse.org/winery/model/selfservice" id="winery-defs-for_ns4-UbuntuNodeTypeImplementation_IA_ArtifactTemplate" targetNamespace="http://www.example.com/tosca/Types/Moodle">
+    <tosca:Import namespace="http://www.example.com/tosca/Types/Moodle" location="../imports/http%253A%252F%252Fwww.w3.org%252F2001%252FXMLSchema/http%253A%252F%252Fwww.example.com%252Ftosca%252FTypes%252FMoodle/MoodleTypes/MoodleTypes.xsd" importType="http://www.w3.org/2001/XMLSchema"/>
+    <tosca:Import namespace="http://www.uni-stuttgart.de/opentosca" location="../imports/http%253A%252F%252Fwww.w3.org%252F2001%252FXMLSchema/http%253A%252F%252Fwww.uni-stuttgart.de%252Fopentosca/WSProperties/WSProperties.xsd" importType="http://www.w3.org/2001/XMLSchema"/>
+    <tosca:Import namespace="http://www.example.com/ToscaTypes" location="ns2__WAR.tosca" importType="http://docs.oasis-open.org/tosca/ns/2011/12"/>
+    <tosca:ArtifactTemplate xmlns:ns2="http://www.example.com/ToscaTypes" id="UbuntuNodeTypeImplementation_IA_ArtifactTemplate" type="ns2:WAR">
+        <tosca:Properties>
+            <opentosca:WSProperties xmlns:opentosca="http://www.uni-stuttgart.de/opentosca" xmlns="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:ns1="http://docs.oasis-open.org/tosca/ns/2011/12/ToscaSpecificTypes" xmlns:ns2="http://docs.oasis-open.org/tosca/ns/2011/12/ToscaBaseTypes" xmlns:tns="http://www.example.com/tosca/Types/Moodle" xmlns:toscatypes="http://www.example.com/ToscaTypes">
+                <opentosca:ServiceEndpoint>/services/org_opentosca_types_Ubuntu__InterfaceUbuntuPort</opentosca:ServiceEndpoint>
+                <opentosca:PortType>{http://opentosca.org/types}org_opentosca_types_Ubuntu__InterfaceUbuntu</opentosca:PortType>
+                <opentosca:InvocationType>SOAP/HTTP</opentosca:InvocationType>
+			</opentosca:WSProperties>
+        </tosca:Properties>
+        <tosca:ArtifactReferences>
+            <tosca:ArtifactReference reference="artifacttemplates/http%253A%252F%252Fwww.example.com%252Ftosca%252FTypes%252FMoodle/UbuntuNodeTypeImplementation_IA_ArtifactTemplate/files/org_opentosca_types_Ubuntu__InterfaceUbuntu.war"/>
+        </tosca:ArtifactReferences>
+    </tosca:ArtifactTemplate>
+</tosca:Definitions>

--- a/Examples/CSARTemplateYAML/ns5__OperatingSystem.tosca
+++ b/Examples/CSARTemplateYAML/ns5__OperatingSystem.tosca
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<tosca:Definitions xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" xmlns:ns31="http://www.eclipse.org/winery/model/selfservice" id="winery-defs-for_ns5-OperatingSystem" targetNamespace="http://docs.oasis-open.org/tosca/ns/2011/12/ToscaBaseTypes">
+    <tosca:Import namespace="http://docs.oasis-open.org/tosca/ns/2011/12/ToscaBaseTypes" location="../imports/http%253A%252F%252Fwww.w3.org%252F2001%252FXMLSchema/http%253A%252F%252Fdocs.oasis-open.org%252Ftosca%252Fns%252F2011%252F12%252FToscaBaseTypes/Artifacts/Artifacts.xsd" importType="http://www.w3.org/2001/XMLSchema"/>
+    <tosca:Import namespace="http://docs.oasis-open.org/tosca/ns/2011/12/ToscaBaseTypes" location="../imports/http%253A%252F%252Fwww.w3.org%252F2001%252FXMLSchema/http%253A%252F%252Fdocs.oasis-open.org%252Ftosca%252Fns%252F2011%252F12%252FToscaBaseTypes/TOSCA-v1.0-BaseTypes/TOSCA-v1.0-BaseTypes.xsd" importType="http://www.w3.org/2001/XMLSchema"/>
+    <tosca:Import namespace="http://www.example.com/tosca/Types/Moodle" location="ns4__UbuntuNodeTypeImplementation.tosca" importType="http://docs.oasis-open.org/tosca/ns/2011/12"/>
+    <tosca:Import namespace="http://docs.oasis-open.org/tosca/ns/2011/12/ToscaBaseTypes" location="ns5__RootNodeType.tosca" importType="http://docs.oasis-open.org/tosca/ns/2011/12"/>
+    <tosca:NodeType name="OperatingSystem" abstract="no" final="no" targetNamespace="http://docs.oasis-open.org/tosca/ns/2011/12/ToscaBaseTypes" winery:bordercolor="#7036b0">
+        <tosca:documentation>Operating System</tosca:documentation>
+        <tosca:DerivedFrom xmlns:ns5="http://docs.oasis-open.org/tosca/ns/2011/12/ToscaBaseTypes" typeRef="ns5:RootNodeType"/>
+    </tosca:NodeType>
+</tosca:Definitions>

--- a/Examples/CSARTemplateYAML/ns5__OperatingSystem.yml
+++ b/Examples/CSARTemplateYAML/ns5__OperatingSystem.yml
@@ -1,0 +1,15 @@
+# Required TOSCA Definitions version string
+tosca_definitions_version: tosca_simple_yaml_1_0
+
+OperatingSystem:
+	derived_from: RootNodeType
+	description: Operating System
+	properties:
+			hostname:
+				type: string
+            sshUser:
+				type: string
+            sshKey:
+				type: string
+            script:
+				type: string		

--- a/Examples/CSARTemplateYAML/ns5__RootNodeType.tosca
+++ b/Examples/CSARTemplateYAML/ns5__RootNodeType.tosca
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<tosca:Definitions xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" xmlns:ns31="http://www.eclipse.org/winery/model/selfservice" id="winery-defs-for_ns5-RootNodeType" targetNamespace="http://docs.oasis-open.org/tosca/ns/2011/12/ToscaBaseTypes">
+    <tosca:Import namespace="http://docs.oasis-open.org/tosca/ns/2011/12/ToscaBaseTypes" location="../imports/http%253A%252F%252Fwww.w3.org%252F2001%252FXMLSchema/http%253A%252F%252Fdocs.oasis-open.org%252Ftosca%252Fns%252F2011%252F12%252FToscaBaseTypes/Artifacts/Artifacts.xsd" importType="http://www.w3.org/2001/XMLSchema"/>
+    <tosca:Import namespace="http://docs.oasis-open.org/tosca/ns/2011/12/ToscaBaseTypes" location="../imports/http%253A%252F%252Fwww.w3.org%252F2001%252FXMLSchema/http%253A%252F%252Fdocs.oasis-open.org%252Ftosca%252Fns%252F2011%252F12%252FToscaBaseTypes/TOSCA-v1.0-BaseTypes/TOSCA-v1.0-BaseTypes.xsd" importType="http://www.w3.org/2001/XMLSchema"/>
+    <tosca:NodeType name="RootNodeType" targetNamespace="http://docs.oasis-open.org/tosca/ns/2011/12/ToscaBaseTypes">
+        <tosca:documentation>Root NodeType</tosca:documentation>
+    </tosca:NodeType>
+</tosca:Definitions>

--- a/Examples/CSARTemplateYAML/ns5__RootNodeType.yml
+++ b/Examples/CSARTemplateYAML/ns5__RootNodeType.yml
@@ -1,0 +1,16 @@
+# Required TOSCA Definitions version string
+tosca_definitions_version: tosca_simple_yaml_1_0
+
+# The TOSCA Node Type all other TOSCA base Node Types derive from
+# The statements beginning at line 9 are extracted from the TOSCA-Simple-Profile-YAML-v1.0 B.6.1 tosca.nodes.Root
+RootNodeType:
+	derived_from: RootNodeType
+	description: Root NodeType
+	requirements:
+		- dependency:
+			type: tosca.capabilities.Feature
+			lower_bound: 0
+			upper_bound: unbounded
+		capabilities:
+			feature: tosca.capabilities.Feature
+		interfaces: [ tosca.interfaces.node.Lifecycle ]	

--- a/Examples/CSARTemplateYAML/ns75__InstallOpenStackVM.tosca
+++ b/Examples/CSARTemplateYAML/ns75__InstallOpenStackVM.tosca
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<tosca:Definitions xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" xmlns:ns31="http://www.eclipse.org/winery/model/selfservice" id="winery-defs-for_ns75-InstallOpenStackVM" targetNamespace="http://types.opentosca.org">
+    <tosca:Import namespace="http://types.opentosca.org/propertiesdefinition/winery" location="../imports/http%253A%252F%252Fwww.w3.org%252F2001%252FXMLSchema/http%253A%252F%252Ftypes.opentosca.org%252Fpropertiesdefinition%252Fwinery/Properties/Properties.xsd" importType="http://www.w3.org/2001/XMLSchema" winery:wpd="true"/>
+    <tosca:Import namespace="http://types.opentosca.org" location="ns75__InstallOpenStackVM_impl.tosca" importType="http://docs.oasis-open.org/tosca/ns/2011/12"/>
+    <tosca:Import namespace="http://types.opentosca.org/propertiesdefinition/winery" location="../nodetypes/http%253A%252F%252Ftypes.opentosca.org/InstallOpenStackVM/propertiesdefinition/Properties.xsd" importType="http://www.w3.org/2001/XMLSchema" winery:wpd="true"/>
+    <tosca:NodeType name="InstallOpenStackVM" targetNamespace="http://types.opentosca.org" winery:bordercolor="#5e351a">
+        <winery:PropertiesDefinition elementname="Properties" namespace="http://types.opentosca.org/propertiesdefinition/winery">
+            <winery:properties>
+                <winery:key>credentials</winery:key>
+                <winery:type>xsd:string</winery:type>
+            </winery:properties>
+            <winery:properties>
+                <winery:key>endpointsAPI</winery:key>
+                <winery:type>xsd:string</winery:type>
+            </winery:properties>
+            <winery:properties>
+                <winery:key>keypair</winery:key>
+                <winery:type>xsd:string</winery:type>
+            </winery:properties>
+            <winery:properties>
+                <winery:key>minDisk</winery:key>
+                <winery:type>xsd:string</winery:type>
+            </winery:properties>
+            <winery:properties>
+                <winery:key>minRAM</winery:key>
+                <winery:type>xsd:string</winery:type>
+            </winery:properties>
+            <winery:properties>
+                <winery:key>flavorId</winery:key>
+                <winery:type>xsd:string</winery:type>
+            </winery:properties>
+            <winery:properties>
+                <winery:key>imageId</winery:key>
+                <winery:type>xsd:string</winery:type>
+            </winery:properties>
+            <winery:properties>
+                <winery:key>imageName</winery:key>
+                <winery:type>xsd:string</winery:type>
+            </winery:properties>
+            <winery:properties>
+                <winery:key>floatingIp</winery:key>
+                <winery:type>xsd:string</winery:type>
+            </winery:properties>
+            <winery:properties>
+                <winery:key>serverId</winery:key>
+                <winery:type>xsd:string</winery:type>
+            </winery:properties>
+            <winery:properties>
+                <winery:key>privKey</winery:key>
+                <winery:type>xsd:string</winery:type>
+            </winery:properties>
+        </winery:PropertiesDefinition>
+        <tosca:PropertiesDefinition xmlns:ns76="http://types.opentosca.org/propertiesdefinition/winery" type="ns76:Properties"/>
+        <tosca:Interfaces>
+            <tosca:Interface name="Custom_InstallVM">
+                <tosca:Operation name="InstallVMwithCustomKeypair">
+                    <tosca:InputParameters>
+                        <tosca:InputParameter name="credentials" type="xsd:string" required="yes"/>
+                        <tosca:InputParameter name="endpointsAPI" type="xsd:string" required="yes"/>
+                        <tosca:InputParameter name="flavorId" type="xsd:string" required="yes"/>
+                        <tosca:InputParameter name="keypair" type="xsd:string" required="yes"/>
+                        <tosca:InputParameter name="imageId" type="xsd:string" required="yes"/>
+                    </tosca:InputParameters>
+                    <tosca:OutputParameters>
+                        <tosca:OutputParameter name="serverId" type="xsd:string" required="yes"/>
+                        <tosca:OutputParameter name="floatingIp" type="xsd:string" required="yes"/>
+                    </tosca:OutputParameters>
+                </tosca:Operation>
+                <tosca:Operation name="InstallVMwithGeneratedKeypair">
+                    <tosca:InputParameters>
+                        <tosca:InputParameter name="credentials" type="xsd:string" required="yes"/>
+                        <tosca:InputParameter name="endpointsAPI" type="xsd:string" required="yes"/>
+                        <tosca:InputParameter name="flavorId" type="xsd:string" required="yes"/>
+                        <tosca:InputParameter name="imageName" type="xsd:string" required="yes"/>
+                    </tosca:InputParameters>
+                    <tosca:OutputParameters>
+                        <tosca:OutputParameter name="serverId" type="xsd:string" required="yes"/>
+                        <tosca:OutputParameter name="floatingIp" type="xsd:string" required="yes"/>
+                        <tosca:OutputParameter name="privKey" type="xsd:string" required="yes"/>
+                    </tosca:OutputParameters>
+                </tosca:Operation>
+                <tosca:Operation name="InstallVMwithCustomFlavor">
+                    <tosca:InputParameters>
+                        <tosca:InputParameter name="credentials" type="xsd:string" required="yes"/>
+                        <tosca:InputParameter name="endpointsAPI" type="xsd:string" required="yes"/>
+                        <tosca:InputParameter name="minDisk" type="xsd:string" required="yes"/>
+                        <tosca:InputParameter name="minRAM" type="xsd:string" required="yes"/>
+                        <tosca:InputParameter name="imageName" type="xsd:string" required="yes"/>
+                        <tosca:InputParameter name="keypair" type="xsd:string" required="yes"/>
+                    </tosca:InputParameters>
+                    <tosca:OutputParameters>
+                        <tosca:OutputParameter name="serverId" type="xsd:string" required="yes"/>
+                        <tosca:OutputParameter name="floatingIp" type="xsd:string" required="yes"/>
+                    </tosca:OutputParameters>
+                </tosca:Operation>
+                <tosca:Operation name="InstallVMwithCustomImage">
+                    <tosca:InputParameters>
+                        <tosca:InputParameter name="credentials" type="xsd:string" required="yes"/>
+                        <tosca:InputParameter name="endpointsAPI" type="xsd:string" required="yes"/>
+                        <tosca:InputParameter name="flavorId" type="xsd:string" required="yes"/>
+                        <tosca:InputParameter name="imageName" type="xsd:string" required="yes"/>
+                        <tosca:InputParameter name="keypair" type="xsd:string" required="yes"/>
+                    </tosca:InputParameters>
+                    <tosca:OutputParameters>
+                        <tosca:OutputParameter name="serverId" type="xsd:string" required="yes"/>
+                        <tosca:OutputParameter name="floatingIp" type="xsd:string" required="yes"/>
+                    </tosca:OutputParameters>
+                </tosca:Operation>
+            </tosca:Interface>
+        </tosca:Interfaces>
+    </tosca:NodeType>
+</tosca:Definitions>

--- a/Examples/CSARTemplateYAML/ns75__InstallOpenStackVM.yml
+++ b/Examples/CSARTemplateYAML/ns75__InstallOpenStackVM.yml
@@ -1,0 +1,31 @@
+# Required TOSCA Definitions version string
+tosca_definitions_version: tosca_simple_yaml_1_0
+
+OperatingSystem:
+	derived_from: RootNodeType
+	description: InstallOpenStackVM
+	
+# Here it is possible to set default values	
+	properties:
+		credentials:
+			type: string
+		endpointsAPI:
+			type: string		
+		keypair:
+			type: string
+		minDisk:
+			type: string
+		minRAM:
+			type: string
+		flavorId:
+			type: string
+		imageId:
+			type: string
+		imageName:
+			type: string
+		floatingIp:
+			type: string
+		serverId:
+			type: string
+		privKey:
+	interfaces: [ Custom_InstallVM ]

--- a/Examples/CSARTemplateYAML/ns75__InstallOpenStackVM_IA.tosca
+++ b/Examples/CSARTemplateYAML/ns75__InstallOpenStackVM_IA.tosca
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<tosca:Definitions xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" xmlns:ns31="http://www.eclipse.org/winery/model/selfservice" id="winery-defs-for_ns75-InstallOpenStackVM_IA" targetNamespace="http://types.opentosca.org">
+    <tosca:Import namespace="http://www.example.com/ToscaTypes" location="ns2__WAR.tosca" importType="http://docs.oasis-open.org/tosca/ns/2011/12"/>
+    <tosca:ArtifactTemplate xmlns:ns2="http://www.example.com/ToscaTypes" id="InstallOpenStackVM_IA" type="ns2:WAR">
+        <tosca:Properties>
+            <ns6:WSProperties xmlns:ns6="http://www.uni-stuttgart.de/opentosca" xmlns="http://www.uni-stuttgart.de/opentosca">
+                <ServiceEndpoint>/services/InstallOpenStackVM_Custom_InstallVMPort</ServiceEndpoint>
+                <PortType>{http://types.opentosca.org}InstallOpenStackVM_Custom_InstallVM</PortType>
+                <InvocationType>SOAP/HTTP</InvocationType>
+            </ns6:WSProperties>
+        </tosca:Properties>
+        <tosca:ArtifactReferences>
+            <tosca:ArtifactReference reference="artifacttemplates/http%253A%252F%252Ftypes.opentosca.org/InstallOpenStackVM_IA/files/InstallOpenStackVM_Custom_InstallVM.war"/>
+        </tosca:ArtifactReferences>
+    </tosca:ArtifactTemplate>
+</tosca:Definitions>

--- a/Examples/CSARTemplateYAML/ns75__InstallOpenStackVM_impl.tosca
+++ b/Examples/CSARTemplateYAML/ns75__InstallOpenStackVM_impl.tosca
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<tosca:Definitions xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" xmlns:ns31="http://www.eclipse.org/winery/model/selfservice" id="winery-defs-for_ns75-InstallOpenStackVM_impl" targetNamespace="http://types.opentosca.org">
+    <tosca:Import namespace="http://www.example.com/ToscaTypes" location="ns2__WAR.tosca" importType="http://docs.oasis-open.org/tosca/ns/2011/12"/>
+    <tosca:Import namespace="http://types.opentosca.org" location="ns75__InstallOpenStackVM_IA.tosca" importType="http://docs.oasis-open.org/tosca/ns/2011/12"/>
+    <tosca:NodeTypeImplementation xmlns:ns75="http://types.opentosca.org" name="InstallOpenStackVM_impl" targetNamespace="http://types.opentosca.org" nodeType="ns75:InstallOpenStackVM">
+        <tosca:ImplementationArtifacts>
+            <tosca:ImplementationArtifact xmlns:ns2="http://www.example.com/ToscaTypes" name="InstallOpenStackVM_IA" interfaceName="Custom_InstallVM" artifactType="ns2:WAR" artifactRef="ns75:InstallOpenStackVM_IA"/>
+        </tosca:ImplementationArtifacts>
+    </tosca:NodeTypeImplementation>
+</tosca:Definitions>

--- a/Examples/CSARTemplateYAML/ns75__InstallVMServTemplate.tosca
+++ b/Examples/CSARTemplateYAML/ns75__InstallVMServTemplate.tosca
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<tosca:Definitions xmlns:tosca="http://docs.oasis-open.org/tosca/ns/2011/12" xmlns:winery="http://www.opentosca.org/winery/extensions/tosca/2013/02/12" xmlns:ns31="http://www.eclipse.org/winery/model/selfservice" id="winery-defs-for_ns75-InstallVMServTemplate" targetNamespace="http://types.opentosca.org">
+    <tosca:Import namespace="http://docs.oasis-open.org/tosca/ns/2011/12/ToscaBaseTypes" location="ns5__OperatingSystem.tosca" importType="http://docs.oasis-open.org/tosca/ns/2011/12"/>
+    <tosca:Import namespace="http://types.opentosca.org" location="ns75__InstallOpenStackVM.tosca" importType="http://docs.oasis-open.org/tosca/ns/2011/12"/>
+    <tosca:ServiceTemplate id="InstallVMServTemplate" name="InstallVMServTemplate" targetNamespace="http://types.opentosca.org">
+        <tosca:TopologyTemplate>
+            <tosca:NodeTemplate xmlns:ns75="http://types.opentosca.org" name="InstallOpenStackVMTemplate" minInstances="1" maxInstances="1" id="InstallOpenStackVMTemplate" type="ns75:InstallOpenStackVM" winery:x="435" winery:y="241">
+                <tosca:Properties>
+                    <ns76:Properties xmlns:ns76="http://types.opentosca.org/propertiesdefinition/winery" xmlns="http://types.opentosca.org/propertiesdefinition/winery" xmlns:ty="http://types.opentosca.org">
+                        <credentials>{"auth":{"tenantId":"4114e1b404404565ac2ccbcc76b8078e","passwordCredentials":{"username":"marzie.dehghanipour","password":"piorkaun"}}}</credentials>
+                        <endpointsAPI>{"os-identity-api":"http:\/\/129.69.209.127:5000\/v2.0","os-tenantId":"4114e1b404404565ac2ccbcc76b8078e"}</endpointsAPI>
+                        <keypair/>
+                        <minDisk/>
+                        <minRAM/>
+                        <flavorId>3</flavorId>
+                        <imageId/>
+                        <imageName>ubuntu-12.04-server-cloudimg-amd64</imageName>
+                        <floatingIp></floatingIp>
+                        <serverId></serverId>
+                        <privKey></privKey>
+					</ns76:Properties>
+                </tosca:Properties>
+            </tosca:NodeTemplate>
+            <tosca:NodeTemplate xmlns:ns5="http://docs.oasis-open.org/tosca/ns/2011/12/ToscaBaseTypes" name="LinuxOperatingSystem" minInstances="1" maxInstances="1" id="LinuxOperatingSystem" type="ns5:OperatingSystem" winery:x="429" winery:y="75">
+            	<tosca:Properties>
+                    <ns6:Properties xmlns:ns6="http://docs.oasis-open.org/tosca/ns/2011/12/ToscaBaseTypes/propertiesdefinition/winery" xmlns="http://docs.oasis-open.org/tosca/ns/2011/12/ToscaBaseTypes/propertiesdefinition/winery" xmlns:ty="http://docs.oasis-open.org/tosca/ns/2011/12/ToscaBaseTypes">
+                    	<hostname></hostname>
+                    	<sshUser>ubuntu</sshUser>
+                    	<sshKey></sshKey>
+                    	<script>uname -a</script> 
+               		</ns6:Properties>
+                </tosca:Properties>   
+            </tosca:NodeTemplate>             
+        </tosca:TopologyTemplate>
+        <tosca:Plans>
+            <tosca:Plan id="InstallVMServTemplateBuildPlan" name="InstallVMServTemplateBuildPlan" planType="http://docs.oasis-open.org/tosca/ns/2011/12/PlanTypes/BuildPlan" planLanguage="http://docs.oasis-open.org/wsbpel/2.0/process/executable">
+                <tosca:InputParameters>
+                    <tosca:InputParameter name="credentials" type="xsd:string" required="yes"/>
+                    <tosca:InputParameter name="endpointsAPI" type="xsd:string" required="yes"/>
+                    <tosca:InputParameter name="flavorId" type="xsd:string" required="yes"/>
+                    <tosca:InputParameter name="keypair" type="xsd:string" required="yes"/>
+                    <tosca:InputParameter name="imageId" type="xsd:string" required="yes"/>
+                    <tosca:InputParameter name="imageName" type="xsd:string" required="yes"/>
+                    <tosca:InputParameter name="minDisk" type="xsd:string" required="yes"/>
+                    <tosca:InputParameter name="minRAM" type="xsd:string" required="yes"/>
+                </tosca:InputParameters>
+                <tosca:OutputParameters>
+                    <tosca:OutputParameter name="selfserviceApplicationUrl" type="xsd:string"/>
+                    <tosca:OutputParameter name="selfserviceMessage" type="xsd:string"/>
+                    <tosca:OutputParameter name="selfservicePolicyMessage" type="xsd:string"/>
+                    <tosca:OutputParameter name="selfserviceStatus" type="xsd:string"/>
+                    <tosca:OutputParameter name="CorrelationID" type="xsd:string"/>
+                </tosca:OutputParameters>
+                <tosca:PlanModelReference reference="../servicetemplates/types.opentosca.org/InstallVMServTemplate/plans/InstallVMServTemplateBuildPlan/InstallVMServTemplateBuildPlan.zip"/>
+            </tosca:Plan>
+        </tosca:Plans>
+    </tosca:ServiceTemplate>
+</tosca:Definitions>

--- a/Examples/CSARTemplateYAML/ns75__InstallVMServTemplate.yml
+++ b/Examples/CSARTemplateYAML/ns75__InstallVMServTemplate.yml
@@ -1,48 +1,60 @@
-tosca_definitions_version: tosca_simple_yaml_1_0 # Required TOSCA Definitions version string
-tosca_default_namespace: http://types.opentosca.org # Optional. default namespace (schema, types version) 
-template_name: InstallVMServTemplate # Optional name of this service template
+# Required TOSCA Definitions version string
+tosca_definitions_version: tosca_simple_yaml_1_0
 
-description: Service Template for installing VMServ # ToDo: Check wether this is neccessary
+# Optional. default namespace (schema, types version) 
+tosca_default_namespace: http://types.opentosca.org 
+
+# Optional name of this service template
+template_name: InstallVMServTemplate 
+
+# ToDo: Check whether this is necessary
+description: Service Template for installing VMServ 
 
 # list of import statements for importing other definitions files 
+# ToDo: Convert these XML files to YAML, check relative path
 imports: 
-	- ns5__OperatingSystem.yaml #ToDo: Convert these XML files to YAML, check relative path
-	- ns75__InstallOpenStackVM.yaml #ToDo: Convert these XML files to YAML, check relative path
-#These are the inputs from plan, check if names can be the same as in properties
+	- ns5__OperatingSystem.yaml 
+	- ns75__InstallOpenStackVM.yaml 
+	
+# list of global input parameters	
+# The following values are extracted from the XML <Plan> <InputParameter> section. ToDo: check if names can be the same as in "properties"
 inputs:
 	minRAM:
 		type: string
 		description: Number of RAM
 	credentials:
 		type: string
-		description: credentials
+		description: Credentials
 	endpointsAPI:
 		type: string
-		description: endpointsAPI
+		description: Endpoint API
 	flavorId:
 		type: string
-		description: flavorId	
+		description: Flavor ID	
 	keypair:
 		type: string
 		description: keypair
 	imageId:
 		type: string
-		description: imageId	
+		description: image ID	
 	imageName:
 		type: string
-		description: Name of image
+		description: Name of the image
 	minDisk:
 		type: string
-		description: Number disks	
-	
-# ToDo: Describe NodeTypes
+		description: Minimal number of disks	
+		
+# list of node templates	
+# ToDo: Describe NodeTypes in YAML
+# ToDo: What if there is no value?
+# ToDo: What if there are duplicated values (input and property value)?
 node_templates:
 	InstallOpenStackVMTemplate:
 		type: InstallOpenStackVM
 		properties:
             credentials: {"auth":{"tenantId":"4114e1b404404565ac2ccbcc76b8078e","passwordCredentials":{"username":"marzie.dehghanipour","password":"piorkaun"}}}
             endpointsAPI: {"os-identity-api":"http:\/\/129.69.209.127:5000\/v2.0","os-tenantId":"4114e1b404404565ac2ccbcc76b8078e"}
-            keypair: {get_input:keypair} #ToDo: What if there is no value
+            keypair: {get_input:keypair} 
             minDisk: {get_input:minDisk}
             minRAM: {get_input:minRAM}
             flavorId: 3
@@ -50,32 +62,34 @@ node_templates:
             imageName: ubuntu-12.04-server-cloudimg-amd64 # or {get_input:imageName}
             floatingIp:
             serverId:
-            privKey>:
+            privKey:
 		
 	LinuxOperatingSystem:
 		type: OperatingSystem
 		properties:
-			hostname: #ToDo: What if there is no value?
+			hostname:
             sshUser: ubuntu
             sshKey:
             script: uname -a
 		constraints:
 			- minInstances: 1
 			- maxInstances: 1
-
+			
+# list of output parameters
+# ToDo: Define output parameters in artifact (for reference see: InstallVMServTemplateBuildPlanArtifacts.wsdl)
 outputs:
 	selfserviceApplicationUrl:	
-		description:
+		description: This is the self service application URL
 		value:
     selfserviceMessage:
-		description:
+		description: This is the self service message
 		value:
     selfservicePolicyMessage:
-		description:
+		description: This is the self service policy message
 		value:
     selfserviceStatus:
-		description:
+		description: This is the self service status
 		value:
     CorrelationID:
-		description:
+		description: This is the correlation ID
 		value:

--- a/Examples/CSARTemplateYAML/ns75__InstallVMServTemplate.yml
+++ b/Examples/CSARTemplateYAML/ns75__InstallVMServTemplate.yml
@@ -1,0 +1,81 @@
+tosca_definitions_version: tosca_simple_yaml_1_0 # Required TOSCA Definitions version string
+tosca_default_namespace: http://types.opentosca.org # Optional. default namespace (schema, types version) 
+template_name: InstallVMServTemplate # Optional name of this service template
+
+description: Service Template for installing VMServ # ToDo: Check wether this is neccessary
+
+# list of import statements for importing other definitions files 
+imports: 
+	- ns5__OperatingSystem.yaml #ToDo: Convert these XML files to YAML, check relative path
+	- ns75__InstallOpenStackVM.yaml #ToDo: Convert these XML files to YAML, check relative path
+#These are the inputs from plan, check if names can be the same as in properties
+inputs:
+	minRAM:
+		type: string
+		description: Number of RAM
+	credentials:
+		type: string
+		description: credentials
+	endpointsAPI:
+		type: string
+		description: endpointsAPI
+	flavorId:
+		type: string
+		description: flavorId	
+	keypair:
+		type: string
+		description: keypair
+	imageId:
+		type: string
+		description: imageId	
+	imageName:
+		type: string
+		description: Name of image
+	minDisk:
+		type: string
+		description: Number disks	
+	
+# ToDo: Describe NodeTypes
+node_templates:
+	InstallOpenStackVMTemplate:
+		type: InstallOpenStackVM
+		properties:
+            credentials: {"auth":{"tenantId":"4114e1b404404565ac2ccbcc76b8078e","passwordCredentials":{"username":"marzie.dehghanipour","password":"piorkaun"}}}
+            endpointsAPI: {"os-identity-api":"http:\/\/129.69.209.127:5000\/v2.0","os-tenantId":"4114e1b404404565ac2ccbcc76b8078e"}
+            keypair: {get_input:keypair} #ToDo: What if there is no value
+            minDisk: {get_input:minDisk}
+            minRAM: {get_input:minRAM}
+            flavorId: 3
+            imageId: {get_input:imageId}
+            imageName: ubuntu-12.04-server-cloudimg-amd64 # or {get_input:imageName}
+            floatingIp:
+            serverId:
+            privKey>:
+		
+	LinuxOperatingSystem:
+		type: OperatingSystem
+		properties:
+			hostname: #ToDo: What if there is no value?
+            sshUser: ubuntu
+            sshKey:
+            script: uname -a
+		constraints:
+			- minInstances: 1
+			- maxInstances: 1
+
+outputs:
+	selfserviceApplicationUrl:	
+		description:
+		value:
+    selfserviceMessage:
+		description:
+		value:
+    selfservicePolicyMessage:
+		description:
+		value:
+    selfserviceStatus:
+		description:
+		value:
+    CorrelationID:
+		description:
+		value:


### PR DESCRIPTION
Hi there! This is the first attempt to convert CSARTemplates InstallVM Service Template to yaml. Keep in mind that this is not complete (we got stuck at the outputs section and namespace information). To compare yaml to xml see "\\CSAR_Template-master\CSAR_Template-master\trunk\Definitions\ns75__InstallVMServTemplate.tosca"