### PR TITLE
Fixes in mapping of interfaces in NodeType and RelationshipType

### DIFF
--- a/org.opentosca.yamlconverter.main/src/main/java/org/opentosca/yamlconverter/switchmapper/Yaml2XmlSwitch.java
+++ b/org.opentosca.yamlconverter.main/src/main/java/org/opentosca/yamlconverter/switchmapper/Yaml2XmlSwitch.java
@@ -299,9 +299,9 @@ public class Yaml2XmlSwitch {
 		this.xsd.append("</xs:complexType>\n");
 	}
 
-	private Interfaces parseNodeTypeInterfaces(Map<String, Map<String, InterfaceDefinition>> interfaces) {
+	private Interfaces parseNodeTypeInterfaces(Map<String, Map<String, Map<String, OperationDefinition>>> interfaces) {
 		final Interfaces result = new Interfaces();
-		for (final Entry<String, Map<String, InterfaceDefinition>> entry : interfaces.entrySet()) {
+		for (final Entry<String, Map<String, Map<String, OperationDefinition>>> entry : interfaces.entrySet()) {
 			final TInterface inf = new TInterface();
 			inf.setName(entry.getKey());
 			// TODO: YAMLmodel Interface Operations

--- a/org.opentosca.yamlconverter.main/src/main/java/org/opentosca/yamlconverter/switchmapper/Yaml2XmlSwitch.java
+++ b/org.opentosca.yamlconverter.main/src/main/java/org/opentosca/yamlconverter/switchmapper/Yaml2XmlSwitch.java
@@ -184,7 +184,7 @@ public class Yaml2XmlSwitch {
 
 	private TRelationshipType case_RelationshipType(Entry<String, RelationshipType> relType) {
 		final TRelationshipType result = new TRelationshipType();
-		for (final Entry<String, Map<String, InterfaceDefinition>> iface : relType.getValue().getInterfaces().entrySet()) {
+		for (final Entry<String, Map<String, Map<String, OperationDefinition>>> iface : relType.getValue().getInterfaces().entrySet()) {
 			// TODO
 		}
 		for (final Entry<String, PropertyDefinition> prop : relType.getValue().getProperties().entrySet()) {

--- a/org.opentosca.yamlconverter.yamlmodel/src/org/opentosca/yamlconverter/yamlmodel/yaml/element/InterfaceDefinition.java
+++ b/org.opentosca.yamlconverter.yamlmodel/src/org/opentosca/yamlconverter/yamlmodel/yaml/element/InterfaceDefinition.java
@@ -7,5 +7,4 @@ package org.opentosca.yamlconverter.yamlmodel.yaml.element;
  */
 public class InterfaceDefinition extends YAMLElement {
 
-
 }

--- a/org.opentosca.yamlconverter.yamlmodel/src/org/opentosca/yamlconverter/yamlmodel/yaml/element/NodeType.java
+++ b/org.opentosca.yamlconverter.yamlmodel/src/org/opentosca/yamlconverter/yamlmodel/yaml/element/NodeType.java
@@ -9,7 +9,8 @@ public class NodeType extends YAMLElement {
 	private Map<String, PropertyDefinition> properties = new HashMap<String, PropertyDefinition>();
 	private Map<String, Object> requirements = new HashMap<String, Object>();
 	private Map<String, Object> capabilities = new HashMap<String, Object>();
-	private Map<String, Map<String, InterfaceDefinition>> interfaces = new HashMap<String, Map<String, InterfaceDefinition>>();
+	private Map<String, Map<String, Map<String, OperationDefinition>>> interfaces =
+			new HashMap<String, Map<String, Map<String, OperationDefinition>>>();
 	private Map<String, Object> artifacts = new HashMap<String, Object>();
 
 
@@ -63,11 +64,11 @@ public class NodeType extends YAMLElement {
 		}
 	}
 
-	public Map<String, Map<String, InterfaceDefinition>> getInterfaces() {
+	public Map<String, Map<String, Map<String, OperationDefinition>>> getInterfaces() {
 		return this.interfaces;
 	}
 
-	public void setInterfaces(Map<String, Map<String, InterfaceDefinition>> interfaces) {
+	public void setInterfaces(Map<String, Map<String, Map<String, OperationDefinition>>> interfaces) {
 		if (interfaces != null) {
 			this.interfaces = interfaces;
 		}

--- a/org.opentosca.yamlconverter.yamlmodel/src/org/opentosca/yamlconverter/yamlmodel/yaml/element/OperationDefinition.java
+++ b/org.opentosca.yamlconverter.yamlmodel/src/org/opentosca/yamlconverter/yamlmodel/yaml/element/OperationDefinition.java
@@ -1,0 +1,36 @@
+package org.opentosca.yamlconverter.yamlmodel.yaml.element;
+
+/**
+ * @author Sebi
+ */
+public class OperationDefinition {
+
+    private String implementation = "";
+
+    public String getImplementation() {
+        return implementation;
+    }
+
+    public void setImplementation(String implementation) {
+        if (implementation != null) {
+            this.implementation = implementation;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        OperationDefinition that = (OperationDefinition) o;
+
+        if (!implementation.equals(that.implementation)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return implementation.hashCode();
+    }
+}

--- a/org.opentosca.yamlconverter.yamlmodel/src/org/opentosca/yamlconverter/yamlmodel/yaml/element/RelationshipType.java
+++ b/org.opentosca.yamlconverter.yamlmodel/src/org/opentosca/yamlconverter/yamlmodel/yaml/element/RelationshipType.java
@@ -7,7 +7,8 @@ import java.util.Map;
 public class RelationshipType extends YAMLElement {
 
 	private Map<String, PropertyDefinition> properties = new HashMap<String, PropertyDefinition>();
-	private Map<String, Map<String, InterfaceDefinition>> interfaces = new HashMap<String, Map<String, InterfaceDefinition>>();
+	private Map<String, Map<String, Map<String, OperationDefinition>>> interfaces =
+			new HashMap<String, Map<String, Map<String, OperationDefinition>>>();
 	private String[] valid_targets;
 
 	public Map<String, PropertyDefinition> getProperties() {
@@ -20,11 +21,11 @@ public class RelationshipType extends YAMLElement {
 		}
 	}
 
-	public Map<String, Map<String, InterfaceDefinition>> getInterfaces() {
+	public Map<String, Map<String, Map<String, OperationDefinition>>> getInterfaces() {
 		return interfaces;
 	}
 
-	public void setInterfaces(Map<String, Map<String, InterfaceDefinition>> interfaces) {
+	public void setInterfaces(Map<String, Map<String, Map<String, OperationDefinition>>> interfaces) {
 		if (interfaces != null) {
 			this.interfaces = interfaces;
 		}


### PR DESCRIPTION
changed mapping to Map(String, Map(String, Map(String, OperationDefinition))). This is necessary because there are three key levels which are dynamic...