### PR TITLE
Added processing of artifacts in node types

### DIFF
--- a/Examples/CSARTemplateYAML/CSAR_Template.yml
+++ b/Examples/CSARTemplateYAML/CSAR_Template.yml
@@ -95,7 +95,7 @@ node_types:
         description: <artifact_description>
         properties:
           ServiceEndpoint: /services/org_opentosca_types_Ubuntu__InterfaceUbuntuPort
-          PortType: {http://opentosca.org/types}org_opentosca_types_Ubuntu__InterfaceUbuntu #TODO define interface
+          PortType: "{http://opentosca.org/types}org_opentosca_types_Ubuntu__InterfaceUbuntu" #TODO define interface
           InvocationType: SOAP/HTTP
 
   InstallOpenStackVM:
@@ -140,7 +140,7 @@ node_types:
         description: <artifact_description>
         properties:
           ServiceEndpoint: /services/InstallOpenStackVM_Custom_InstallVMPort
-          PortType: {http://types.opentosca.org}InstallOpenStackVM_Custom_InstallVM
+          PortType: "{http://types.opentosca.org}InstallOpenStackVM_Custom_InstallVM"
           InvocationType: SOAP/HTTP
 
 capability_types:
@@ -154,7 +154,7 @@ artifact_types:
   WAR:
     description: <artifact_description>
     mime_type: application/x-zip
-    file_ext: war
+    file_ext: [war]
     properties:
       ServiceEndpoint:
         type: string

--- a/org.opentosca.yamlconverter.main/src/main/java/org/opentosca/yamlconverter/main/YamlBeansConverter.java
+++ b/org.opentosca.yamlconverter.main/src/main/java/org/opentosca/yamlconverter/main/YamlBeansConverter.java
@@ -65,6 +65,7 @@ public class YamlBeansConverter implements IToscaYaml2YamlBeanConverter {
 //		config.setPropertyElementType(RelationshipType.class, "interfaces", OperationDefinition.class);
 		config.setPropertyElementType(CapabilityType.class, "properties", PropertyDefinition.class);
 		config.setPropertyElementType(CapabilityDefinition.class, "properties", PropertyDefinition.class);
+		config.setPropertyElementType(ArtifactType.class, "properties", PropertyDefinition.class);
 	}
 
 }

--- a/org.opentosca.yamlconverter.main/src/main/java/org/opentosca/yamlconverter/switchmapper/Yaml2XmlSwitch.java
+++ b/org.opentosca.yamlconverter.main/src/main/java/org/opentosca/yamlconverter/switchmapper/Yaml2XmlSwitch.java
@@ -282,7 +282,7 @@ public class Yaml2XmlSwitch {
 
 		if (value.getArtifacts() != null) {
 			// here are only artifact definitions!!
-			// TODO: how to handle artifacts??
+			parseNodeTypeArtifacts(value.getArtifacts());
 		}
 		if (value.getCapabilities() != null) {
 			result.setCapabilityDefinitions(parseNodeTypeCapabilities(value.getCapabilities()));
@@ -303,6 +303,40 @@ public class Yaml2XmlSwitch {
 			result.getDocumentation().add(toDocumentation(value.getDescription()));
 		}
 		return result;
+	}
+
+	private void parseNodeTypeArtifacts(List<Map<String, Object>> artifacts) {
+		for (Map<String, Object> artifact : artifacts) {
+			String artifactName = "";
+			String artifactFileUri = "";
+			String artifactType = "";
+			String artifactDescription = "";
+			String artifactMimeType = "";
+			Map additionalProperties = null;
+
+			for (Entry<String, Object> artifactEntry : artifact.entrySet()) {
+				switch (artifactEntry.getKey()) {
+					case "type":
+						artifactType = (String) artifactEntry.getValue();
+						break;
+					case "description":
+						artifactDescription = (String) artifactEntry.getValue();
+						break;
+					case "mime_type":
+						artifactMimeType = (String) artifactEntry.getValue();
+						break;
+					default:
+						artifactName = artifactEntry.getKey();
+						if (artifactEntry.getValue() instanceof String) {
+							artifactFileUri = (String) artifactEntry.getValue();
+						} else if (artifactEntry.getValue() instanceof Map<?, ?>) {
+							additionalProperties = (Map) artifactEntry.getValue();
+						}
+						break;
+				}
+			}
+			// TODO: how to handle artifacts??
+		}
 	}
 
 	private RequirementDefinitions parseNodeTypeRequirementDefinitions(List<Map<String, Object>> requirements) {

--- a/org.opentosca.yamlconverter.main/src/main/java/org/opentosca/yamlconverter/switchmapper/Yaml2XmlSwitch.java
+++ b/org.opentosca.yamlconverter.main/src/main/java/org/opentosca/yamlconverter/switchmapper/Yaml2XmlSwitch.java
@@ -11,6 +11,7 @@ import org.opentosca.model.tosca.TNodeType.RequirementDefinitions;
 import org.opentosca.yamlconverter.main.utils.AnyMap;
 import org.opentosca.yamlconverter.yamlmodel.yaml.element.*;
 
+import javax.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -402,7 +403,7 @@ public class Yaml2XmlSwitch {
 		artifactTemplate.setArtifactReferences(artifactReferences);
 
 		TEntityTemplate.Properties properties = new TEntityTemplate.Properties();
-		properties.setAny(new AnyMap(parseProperties(additionalProperties, artifactType)));
+		properties.setAny(getAnyMapForProperties(additionalProperties, artifactType));
 		artifactTemplate.setProperties(properties);
 
 		artifactTemplates.add(artifactTemplate);
@@ -553,15 +554,19 @@ public class Yaml2XmlSwitch {
 
 	private void processPropertiesInNodeTemplate(NodeTemplate nodeTemplate, String nodename, TNodeTemplate result) {
 		final TEntityTemplate.Properties prop = new TEntityTemplate.Properties();
-		final AnyMap properties = new AnyMap(parseProperties(nodeTemplate.getProperties(), nodename));
-		final JAXBElement<AnyMap> jaxbprop = new JAXBElement<AnyMap>(new QName(TYPESNS, nodename + "Properties", "types"), AnyMap.class,
-				properties);
+		final JAXBElement<AnyMap> jaxbprop = getAnyMapForProperties(nodeTemplate.getProperties(), nodename);
 		prop.setAny(jaxbprop);
 		result.setProperties(prop);
 	}
 
+	private JAXBElement<AnyMap> getAnyMapForProperties(final Map<String, Object> customMap, final String nodename) {
+		final AnyMap properties = new AnyMap(parseProperties(customMap));
+		return new JAXBElement<AnyMap>(new QName(TYPESNS, nodename + "Properties", "types"), AnyMap.class,
+				properties);
+	}
+
 	@SuppressWarnings("unchecked")
-	private Map<String, String> parseProperties(Map<String, Object> properties, String nodename) {
+	private Map<String, String> parseProperties(Map<String, Object> properties) {
 		final Map<String, String> result = new HashMap<String, String>();
 		for (final Entry<String, Object> entry : properties.entrySet()) {
 			String value = "";

--- a/org.opentosca.yamlconverter.main/src/main/java/org/opentosca/yamlconverter/switchmapper/Yaml2XmlSwitch.java
+++ b/org.opentosca.yamlconverter.main/src/main/java/org/opentosca/yamlconverter/switchmapper/Yaml2XmlSwitch.java
@@ -77,6 +77,7 @@ public class Yaml2XmlSwitch {
 	public Definitions parse(ServiceTemplate st) {
 		this.xsd = new StringBuilder(); // reset
 		this.st = st;
+		this.toscaResult = new Definitions();
 		return processServiceTemplate(st);
 	}
 

--- a/org.opentosca.yamlconverter.main/src/main/resources/yaml/CSAR_Template.yml
+++ b/org.opentosca.yamlconverter.main/src/main/resources/yaml/CSAR_Template.yml
@@ -53,8 +53,8 @@ node_templates:
   InstallOpenStackVMTemplate:
     type: InstallOpenStackVM
     properties:
-      credentials: {"auth": {"tenantId": "4114e1b404404565ac2ccbcc76b8078e","passwordCredentials": {"username": "marzie.dehghanipour","password": "piorkaun"}}}
-      endpointsAPI: {"os-identity-api": "http://129.69.209.127: 5000/v2.0","os-tenantId": "4114e1b404404565ac2ccbcc76b8078e"}
+      credentials: "{'auth': {'tenantId': '4114e1b404404565ac2ccbcc76b8078e','passwordCredentials': {'username': 'marzie.dehghanipour','password': 'piorkaun'}}}"
+      endpointsAPI: "{'os-identity-api': 'http://129.69.209.127: 5000/v2.0','os-tenantId': '4114e1b404404565ac2ccbcc76b8078e'}"
       keypair: {get_input: keypair} 
       minDisk: {get_input: minDisk}
       minRAM: {get_input: minRAM}

--- a/org.opentosca.yamlconverter.main/src/main/resources/yaml/CSAR_Template.yml
+++ b/org.opentosca.yamlconverter.main/src/main/resources/yaml/CSAR_Template.yml
@@ -97,7 +97,7 @@ node_types:
       script:
         type: string
     artifacts:
-      - UbuntuNodeTypeImplementation_IA_ArtifactTemplate:
+      - UbuntuNodeTypeImplementation_IA_ArtifactTemplate: org_opentosca_types_Ubuntu__InterfaceUbuntu.war
         type: WAR
         description: <artifact_description>
         properties:
@@ -145,21 +145,26 @@ node_types:
         InstallVMwithCustomImage:
           implementation: InstallOpenStackVM_IA
     artifacts:
-      - InstallOpenStackVM_IA:
+      - InstallOpenStackVM_IA: InstallOpenStackVM_Custom_InstallVM.war
         type: WAR
         description: <artifact_description>
         properties:
           ServiceEndpoint: /services/InstallOpenStackVM_Custom_InstallVMPort
-          PortType: "{http://types.opentosca.org}InstallOpenStackVM_Custom_InstallVM" #TODO define interface
+          PortType: "{http://types.opentosca.org}InstallOpenStackVM_Custom_InstallVM"
           InvocationType: SOAP/HTTP
 
 artifact_types:
-  InstallOpenStackVM_IA:
-    mime_type: war
-    description: bla
-    derived_from: tosca.artifact.Root
-    file_ext: [jar]
-    mime_type: application/java-archive
+  WAR:
+    description: <artifact_description>
+    mime_type: application/x-zip
+    file_ext: [war]
+    properties:
+      ServiceEndpoint:
+        type: string
+      PortType:
+        type: string
+      InvocationType:
+        type: string
 
 capability_types:
   testCap:

--- a/org.opentosca.yamlconverter.main/src/main/resources/yaml/CSAR_Template.yml
+++ b/org.opentosca.yamlconverter.main/src/main/resources/yaml/CSAR_Template.yml
@@ -152,6 +152,13 @@ node_types:
           ServiceEndpoint: /services/InstallOpenStackVM_Custom_InstallVMPort
           PortType: "{http://types.opentosca.org}InstallOpenStackVM_Custom_InstallVM"
           InvocationType: SOAP/HTTP
+      - DeleteOpenStackVM_IA: DeleteOpenStackVM_Custom_InstallVM.war
+        type: WAR
+        description: <artifact_description>
+        properties:
+          ServiceEndpoint: /services/DeleteOpenStackVM_Custom_DeleteVMPort
+          PortType: "{http://types.opentosca.org}DeleteOpenStackVM_Custom_DeleteVM"
+          InvocationType: SOAP/HTTP
 
 artifact_types:
   WAR:


### PR DESCRIPTION
Artifacts are now processed in NodeTypes. One artifact will produce an ArtifactTemplate which is referenced in an ImplementationArtifact from a NodeTypeImplementation. The mapping of artifacts and interfaces for an ImplementationArtifact is ugly, but currently the only way (the parser checks if a name of an operation is contained by the artifact reference/name). This pull request should fulfill the basic needs of #74 